### PR TITLE
Bug fix for Translate transform - unary operator can't act on a tuple

### DIFF
--- a/napari/layers/transforms.py
+++ b/napari/layers/transforms.py
@@ -82,7 +82,7 @@ class Translate(Transform):
 
     @property
     def inverse(self):
-        return Translate(-self.translate)
+        return Translate(-np.array(self.vector))
 
     def set_slice(self, axes: Sequence[int]) -> Translate:
         return Translate(self.translate[axes])


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
This is the fix for [the comment I made earlier](https://github.com/napari/napari/pull/885/files/53bcf488898f0f2f7a75bffe5697d383fe8ac34f#r375610089). I can't make github review suggestions on your PR, so here's a pull request for your convenience.

> ```python
>     @property
>     def inverse(self):
>         return Translate(-self.vector)
> ```
> I think you need something like `return Translate(-np.array(self.vector))` here instead. 
Right now I get a "TypeError: bad operand type for unary -: 'tuple'" (which makes sense, `self.vector` is actually a tuple).

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug-fix (non-breaking change which fixes an issue)

