### PR TITLE
[WIP] key and mouse bindings

### DIFF
--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -49,27 +49,25 @@ def activate_label_erase_mode(layer):
 
 
 @register_label_action(
-    trans._(
-        "Set the currently selected label to the largest used label plus one."
-    ),
+    trans._("Set the active label to the largest used label plus one."),
 )
 def new_label(layer):
-    """Set the currently selected label to the largest used label plus one."""
-    layer.selected_label = layer.data.max() + 1
+    """Set the active label to the largest used label plus one."""
+    layer.active_label = layer.data.max() + 1
 
 
 @register_label_action(
-    trans._("Decrease the currently selected label by one."),
+    trans._("Decrease the active label by one."),
 )
 def decrease_label_id(layer):
-    layer.selected_label -= 1
+    layer.active_label -= 1
 
 
 @register_label_action(
-    trans._("Increase the currently selected label by one."),
+    trans._("Increase the active label by one."),
 )
 def increase_label_id(layer):
-    layer.selected_label += 1
+    layer.active_label += 1
 
 
 @Labels.bind_key('Control-Z')

--- a/napari/layers/labels/_labels_mouse_bindings.py
+++ b/napari/layers/labels/_labels_mouse_bindings.py
@@ -3,21 +3,21 @@ from ._labels_utils import interpolate_coordinates
 
 
 def draw(layer, event):
-    """Draw with the currently selected label to a coordinate.
+    """Draw with the current active label to a coordinate.
 
     This method have different behavior when draw is called
     with different labeling layer mode.
 
     In PAINT mode the cursor functions like a paint brush changing any
     pixels it brushes over to the current label. If the background label
-    `0` is selected than any pixels will be changed to background and this
+    `0` is active than any pixels will be changed to background and this
     tool functions like an eraser. The size and shape of the cursor can be
     adjusted in the properties widget.
 
     In FILL mode the cursor functions like a fill bucket replacing pixels
     of the label clicked on with the current label. It can either replace
     all pixels of that label or just those that are contiguous with the
-    clicked on pixel. If the background label `0` is selected than any
+    clicked on pixel. If the background label `0` is active than any
     pixels will be changed to background and this tool functions like an
     eraser
     """
@@ -26,7 +26,7 @@ def draw(layer, event):
     if layer._mode == Mode.ERASE:
         new_label = layer._background_label
     else:
-        new_label = layer.selected_label
+        new_label = layer.active_label
 
     if layer._mode in [Mode.PAINT, Mode.ERASE]:
         layer.paint(coordinates, new_label)
@@ -57,6 +57,8 @@ def draw(layer, event):
 
 
 def pick(layer, event):
-    """Change the selected label to the same as the region clicked."""
+    """
+    Change the active label to the same as the region clicked.
+    """
     # on press
-    layer.selected_label = layer.get_value(event.position, world=True) or 0
+    layer.active_label = layer.get_value(event.position, world=True) or 0


### PR DESCRIPTION
# Description
Removed some deprecated stuff from key and mouse bindings.

While I was trying to work on selecting multiple lables using the mouse, I encountered a couple of problems:
- `Ctrl` does not work as intended: the layer stays in fill mode permanently, rather than temporarily. I'm not sure where this is happening, cause there is some magic going on thanks to the `yield` statement. I'm not sure if this happens with other press-n-hold key bindings.
- I don't know whether we need to introduce another layer mode for the multipicking, or how otherwise I can alter the `pick` function to do what we need. Suggestions appreciated! :)